### PR TITLE
feat: PIZ-4 add CI workflow for test/coverage

### DIFF
--- a/.github/workflows/ci-pizza.yml
+++ b/.github/workflows/ci-pizza.yml
@@ -1,0 +1,36 @@
+name: CI Workflow for Pizza
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: python -m pytest app/test
+      - name: Check code coverage
+        run: |
+          coverage run --source=app -m pytest -v app/test && coverage report -m --fail-under=90

--- a/.github/workflows/ci-pizza.yml
+++ b/.github/workflows/ci-pizza.yml
@@ -33,4 +33,4 @@ jobs:
         run: python -m pytest app/test
       - name: Check code coverage
         run: |
-          coverage run --source=app -m pytest -v app/test && coverage report -m --fail-under=90
+          coverage run --source=app -m pytest -v app/test && coverage report -m --fail-under=85 --omit 'app/test/*'

--- a/.github/workflows/ci-pizza.yml
+++ b/.github/workflows/ci-pizza.yml
@@ -34,3 +34,4 @@ jobs:
       - name: Check code coverage
         run: |
           coverage run --source=app -m pytest -v app/test && coverage report -m --fail-under=85 --omit 'app/test/*'
+          

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alembic==1.7.5
 attrs==21.4.0
 autopep8==1.6.0
 click==8.0.3
+coverage==7.2.1
 flake8==4.0.1
 Flask==2.0.2
 Flask-Cors==3.0.10


### PR DESCRIPTION
#### 🤔 Why?

We are creating a CI job with GitHub actions to ensure that test coverage does not decrease when new changes are introduced via a pull request. This will help us catch potential regressions early and ensure that our codebase remains stable and reliable.

From now on, we would start requesting developers 85% coverage.

#### 🛠 What I changed:

- Created a new GitHub actions workflow file to run the tests and calculate code coverage.
- Added the workflow to the repository so that it runs automatically when a pull request is created.

#### 🗃️ Trello Issues:

[PIZ-4 - Increase test coverage](https://trello.com/c/e7jdhu96)