### PR TITLE
refactor: PIZ-9 rename OrderDetails into IngredientsDetails

### DIFF
--- a/app/repositories/managers.py
+++ b/app/repositories/managers.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Sequence
 
 from sqlalchemy.sql import text, column
 
-from .models import Ingredient, Order, OrderDetail, Size, db
+from .models import Ingredient, Order, IngredientDetail, Size, db
 from .serializers import (IngredientSerializer, OrderSerializer,
                           SizeSerializer, ma)
 
@@ -63,7 +63,7 @@ class OrderManager(BaseManager):
         cls.session.add(new_order)
         cls.session.flush()
         cls.session.refresh(new_order)
-        cls.session.add_all((OrderDetail(order_id=new_order._id, ingredient_id=ingredient._id, ingredient_price=ingredient.price)
+        cls.session.add_all((IngredientDetail(order_id=new_order._id, ingredient_id=ingredient._id, ingredient_price=ingredient.price)
                              for ingredient in ingredients))
         cls.session.commit()
         return cls.serializer().dump(new_order)

--- a/app/repositories/models.py
+++ b/app/repositories/models.py
@@ -14,7 +14,7 @@ class Order(db.Model):
     size_id = db.Column(db.Integer, db.ForeignKey('size._id'))
 
     size = db.relationship('Size', backref=db.backref('size'))
-    detail = db.relationship('OrderDetail', backref=db.backref('order_detail'))
+    ingredients = db.relationship('IngredientDetail', backref=db.backref('ingredient_detail'))
 
 
 class Ingredient(db.Model):
@@ -29,7 +29,7 @@ class Size(db.Model):
     price = db.Column(db.Float, nullable=False)
 
 
-class OrderDetail(db.Model):
+class IngredientDetail(db.Model):
     _id = db.Column(db.Integer, primary_key=True)
     ingredient_price = db.Column(db.Float)
     order_id = db.Column(db.Integer, db.ForeignKey('order._id'))

--- a/app/repositories/serializers.py
+++ b/app/repositories/serializers.py
@@ -1,5 +1,5 @@
 from app.plugins import ma
-from .models import Ingredient, Size, Order, OrderDetail
+from .models import Ingredient, Size, Order, IngredientDetail
 
 
 class IngredientSerializer(ma.SQLAlchemyAutoSchema):
@@ -18,12 +18,12 @@ class SizeSerializer(ma.SQLAlchemyAutoSchema):
         fields = ('_id', 'name', 'price')
 
 
-class OrderDetailSerializer(ma.SQLAlchemyAutoSchema):
+class IngredientDetailSerializer(ma.SQLAlchemyAutoSchema):
 
     ingredient = ma.Nested(IngredientSerializer)
 
     class Meta:
-        model = OrderDetail
+        model = IngredientDetail
         load_instance = True
         fields = (
             'ingredient_price',
@@ -33,7 +33,7 @@ class OrderDetailSerializer(ma.SQLAlchemyAutoSchema):
 
 class OrderSerializer(ma.SQLAlchemyAutoSchema):
     size = ma.Nested(SizeSerializer)
-    detail = ma.Nested(OrderDetailSerializer, many=True)
+    ingredients = ma.Nested(IngredientDetailSerializer, many=True)
 
     class Meta:
         model = Order
@@ -47,5 +47,5 @@ class OrderSerializer(ma.SQLAlchemyAutoSchema):
             'date',
             'total_price',
             'size',
-            'detail'
+            'ingredients'
         )

--- a/app/test/conftest.py
+++ b/app/test/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from app import create_app, register_blueprints
 from app.plugins import db, ma
 # flake8: noqa
-from app.repositories.models import Ingredient, Order, OrderDetail, Size
+from app.repositories.models import Ingredient, Order, IngredientDetail, Size
 
 from .fixtures.ingredient import *
 from .fixtures.order import *

--- a/app/test/controllers/test_order.py
+++ b/app/test/controllers/test_order.py
@@ -41,8 +41,7 @@ def test_create(app, ingredients, size, client_data):
         pytest.assume(value == created_order[param])
         pytest.assume(created_order['_id'])
         pytest.assume(size_id == created_order['size']['_id'])
-
-        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['detail'])
+        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['ingredients'])
         pytest.assume(not ingredients_in_detail.difference(ingredient_ids))
 
 
@@ -65,7 +64,7 @@ def test_get_by_id(app, ingredients, size, client_data):
         pytest.assume(order_from_db[param] == value)
         pytest.assume(size_id == created_order['size']['_id'])
 
-        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['detail'])
+        ingredients_in_detail = set(item['ingredient']['_id'] for item in created_order['ingredients'])
         pytest.assume(not ingredients_in_detail.difference(ingredient_ids))
 
 

--- a/app/test/services/test_order.py
+++ b/app/test/services/test_order.py
@@ -13,7 +13,7 @@ def test_create_order_service(create_order):
     pytest.assume(order['date'])
     pytest.assume(order['total_price'])
     pytest.assume(order['size'])
-    pytest.assume(order['detail'])
+    pytest.assume(order['ingredients'])
 
 def test_get_order_by_id_service(client, create_order, order_uri):
     current_order = create_order.json

--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,7 @@ from flask_migrate import Migrate
 from app import flask_app
 from app.plugins import db
 # flake8: noqa
-from app.repositories.models import Ingredient, Order, OrderDetail, Size
+from app.repositories.models import Ingredient, Order, IngredientDetail, Size
 
 
 manager = FlaskGroup(flask_app)


### PR DESCRIPTION
#### 🤔 Why?

- In order to [add the new beverage option](https://trello.com/c/KmvljzVj), the team considered necessary to rename OrderDetails into IngredientsDetails

#### 🛠 What I changed:

- Change OrderDetails class name into IngredientDetails
- Change the order to receive ingredients instead of details

#### 🗃️ Trello Issues:

- [PIZ-9 - Rename OrderDetails to IngredientDetails](https://trello.com/c/HYrnF3ed)
- [PIZ2 - Add a beverage model, manager and service](https://trello.com/c/KmvljzVj)
