### PR TITLE
feat: PIZ-13 CD Workflow for deploying backend

### DIFF
--- a/.github/workflows/cd-pizza.yml
+++ b/.github/workflows/cd-pizza.yml
@@ -1,0 +1,25 @@
+name: CD Workflow for Pizza Backend
+
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install Serverless
+        run: npm install -g serverless
+      - name: Install Dependencies
+        run: npm install
+      - name: Deploy to AWS
+        run: sls deploy --stage prod --verbose --conceal
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,3 @@ pizza.sqlite
 .serverless/
 node_modules/
 package-lock.json
-package.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "serverless-domain-manager": "^6.4.4",
+    "serverless-dotenv-plugin": "^4.0.2",
+    "serverless-python-requirements": "^6.0.0",
+    "serverless-wsgi": "^3.0.2"
+  }
+}


### PR DESCRIPTION
#### 🤔 Why?

Adds a CD workflow to deploy the pizza backend to AWS automatically to save time and reduce the risk of errors during manual deployments.

#### 🛠 What I changed:

- Added a CD workflow for the pizza backend to deploy it automatically to AWS.
- Included the necessary steps in the workflow to install dependencies, set up Node.js, and deploy to AWS.
- Updated .gitignore to exclude certain files.
- Included serverless dependencies in a package.json file

#### 🗃️ Trello Issues:

[PIZ-13 - Create CD Github Actions Workflow](https://trello.com/c/tO72m6P5)
