### PR TITLE
fix: PIZ-14 added pg8000 & forced int type in _id

### DIFF
--- a/.github/workflows/cd-pizza.yml
+++ b/.github/workflows/cd-pizza.yml
@@ -8,15 +8,12 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/app/controllers/base.py
+++ b/app/controllers/base.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Tuple
 from sqlalchemy.exc import SQLAlchemyError
 from ..repositories.managers.base import BaseManager
 
-
+import logging
 class BaseController:
     manager: Optional[BaseManager] = None
 
@@ -11,6 +11,7 @@ class BaseController:
         try:
             return cls.manager.get_by_id(_id), None
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return None, str(ex)
 
     @classmethod
@@ -18,6 +19,7 @@ class BaseController:
         try:
             return cls.manager.get_all(), None
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return None, str(ex)
 
     @classmethod
@@ -25,6 +27,7 @@ class BaseController:
         try:
             return cls.manager.create(entry), None
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return None, str(ex)
 
     @classmethod
@@ -33,6 +36,7 @@ class BaseController:
             _id = new_values.pop('_id', None)
             if not _id:
                 return None, 'Error: No id was provided for update'
-            return cls.manager.update(_id, new_values), None
+            return cls.manager.update(int(_id), new_values), None
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return None, str(ex)

--- a/app/controllers/index.py
+++ b/app/controllers/index.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from ..repositories.managers.db_status import DBStatusManager
 
-
+import logging
 class IndexController:
 
     @staticmethod
@@ -12,4 +12,5 @@ class IndexController:
             DBStatusManager.test_connection()
             return True, ''
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return False, str(ex)

--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -9,6 +9,9 @@ from ..repositories.managers.ingredient import IngredientManager
 from .base import BaseController
 from datetime import datetime
 
+import logging 
+
+
 class OrderController(BaseController):
     manager = OrderManager
     __required_info = ('client_name',
@@ -48,4 +51,5 @@ class OrderController(BaseController):
             order_with_price = {**current_order, 'total_price': price}
             return cls.manager.create(order_with_price, ingredients, beverages), None
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return None, str(ex)

--- a/app/controllers/report.py
+++ b/app/controllers/report.py
@@ -1,6 +1,8 @@
 from ..repositories.managers.report import ReportManager
 from sqlalchemy.exc import SQLAlchemyError
 
+import logging
+
 
 class ReportController:
     manager = ReportManager
@@ -10,4 +12,5 @@ class ReportController:
         try:
             return cls.manager.get_all_reports(), None
         except (SQLAlchemyError, RuntimeError) as ex:
+            logging.error(ex)
             return None, str(ex)

--- a/app/repositories/managers/beverage.py
+++ b/app/repositories/managers/beverage.py
@@ -11,4 +11,4 @@ class BeverageManager(BaseManager):
 
     @classmethod
     def get_by_id_list(cls, ids: Sequence):
-        return cls.session.query(cls.model).filter(cls.model._id.in_(set(ids))).all() or []
+        return cls.session.query(cls.model).filter(cls.model._id.in_(set([int(id) for id in ids]))).all() or []

--- a/app/repositories/managers/ingredient.py
+++ b/app/repositories/managers/ingredient.py
@@ -11,4 +11,4 @@ class IngredientManager(BaseManager):
 
     @classmethod
     def get_by_id_list(cls, ids: Sequence):
-        return cls.session.query(cls.model).filter(cls.model._id.in_(set(ids))).all() or []
+        return cls.session.query(cls.model).filter(cls.model._id.in_(set([int(id) for id in ids]))).all() or []

--- a/app/settings.py
+++ b/app/settings.py
@@ -6,4 +6,4 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 class Config:
     DEBUG = True
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = f'postgresql://{os.getenv("DB_USER")}:{os.getenv("DB_PASSWORD")}@{os.getenv("DB_HOST")}:{os.getenv("DB_PORT")}/{os.getenv("DB_NAME")}'
+    SQLALCHEMY_DATABASE_URI = f'postgresql+pg8000://{os.getenv("DB_USER")}:{os.getenv("DB_PASSWORD")}@{os.getenv("DB_HOST")}:{os.getenv("DB_PORT")}/{os.getenv("DB_NAME")}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.10.2
+asn1crypto==1.5.1
 attrs==22.2.0
 autopep8==2.0.2
 click==8.1.3
@@ -24,6 +25,7 @@ marshmallow==3.9.0
 marshmallow-sqlalchemy==0.29.0
 mccabe==0.7.0
 packaging==23.0
+pg8000==1.29.4
 pluggy==1.0.0
 psycopg2==2.9.5
 psycopg2-binary==2.9.5
@@ -35,6 +37,7 @@ pytest==7.2.2
 pytest-assume==2.4.3
 python-dateutil==2.8.2
 python-dotenv==1.0.0
+scramp==1.4.4
 six==1.16.0
 SQLAlchemy==2.0.7
 toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,6 @@ mccabe==0.7.0
 packaging==23.0
 pg8000==1.29.4
 pluggy==1.0.0
-psycopg2==2.9.5
-psycopg2-binary==2.9.5
 py==1.11.0
 pycodestyle==2.10.0
 pyflakes==3.0.1


### PR DESCRIPTION
#### 🤔 Why?

Since the PostgreSQL client installed on the AWS Lambda runners don't have the `libpq` library installed, we have decided to move away from the `psycopg` PostgreSQL client to the `pg8000` client

#### 🛠 What I changed:

- Removed psycopg2 dependency
- Added pg8000 dependency
- Added explicit int conversion for _id's when querying them from the database
- Improved error logging

#### 🗃️ Trello Issues:

List of Trello issue links (using bullet points) or name your PR using the ticket number at the beginning along with a description (e.g. PZ-123: Fix Login Page UI) - if no issue exists, coordinate with team lead to make one

[PIZ-14 - Change psycopg2 to pg8000](https://trello.com/c/yBRQsWHr)