### PR TITLE
fix: PIZ-15 deploy only if CI passes

### DIFF
--- a/.github/workflows/cd-pizza.yml
+++ b/.github/workflows/cd-pizza.yml
@@ -1,9 +1,13 @@
 name: CD Workflow for Pizza Backend
 
-on: 
-  push:
-    branches:
-      - main
+
+
+on:
+  workflow_run:
+    workflows: ["build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   deploy:

--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,7 @@ from app.repositories.models import Ingredient, Order, IngredientDetail, Size
 
 from seed import seeder
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG, force=True)
 
 manager = FlaskGroup(flask_app)
 


### PR DESCRIPTION
#### 🤔 Why?

Currently, when a PR is merged to main, both CI run in parallel. This PR ensures that the CD runs only after the CI finishes successfully.

#### 🛠 What I changed:

- CD Workflow trigger
- Logging setup

#### 🗃️ Trello Issues:

[PIZ-15 - Deploy only if CI passes](https://trello.com/c/RBIxRcNe)
