### PR TITLE
Strict type conversion for db

### DIFF
--- a/app/controllers/base.py
+++ b/app/controllers/base.py
@@ -9,7 +9,7 @@ class BaseController:
     @classmethod
     def get_by_id(cls, _id: Any) -> Tuple[Any, Optional[str]]:
         try:
-            return cls.manager.get_by_id(_id), None
+            return cls.manager.get_by_id(int(_id)), None
         except (SQLAlchemyError, RuntimeError) as ex:
             logging.error(ex)
             return None, str(ex)

--- a/app/repositories/managers/base.py
+++ b/app/repositories/managers/base.py
@@ -19,8 +19,7 @@ class BaseManager:
     @classmethod
     def get_by_id(cls, _id: Any):
         entry = cls.model.query.get(int(_id))
-        x = cls.serializer().dump(entry)
-        return x
+        return cls.serializer().dump(entry)
 
     @classmethod
     def create(cls, entry: dict):

--- a/app/repositories/managers/base.py
+++ b/app/repositories/managers/base.py
@@ -18,8 +18,9 @@ class BaseManager:
 
     @classmethod
     def get_by_id(cls, _id: Any):
-        entry = cls.model.query.get(_id)
-        return cls.serializer().dump(entry)
+        entry = cls.model.query.get(int(_id))
+        x = cls.serializer().dump(entry)
+        return x
 
     @classmethod
     def create(cls, entry: dict):
@@ -31,7 +32,7 @@ class BaseManager:
 
     @classmethod
     def update(cls, _id: Any, new_values: dict):
-        cls.session.query(cls.model).filter_by(_id=_id).update(new_values)
+        cls.session.query(cls.model).filter_by(_id=int(_id)).update(new_values)
         cls.session.commit()
         return cls.get_by_id(_id)
 


### PR DESCRIPTION
#### 🤔 Why?

- Our db driver requires us to be specify about the types of the data that we are sending to the database. That's why in this PR we have force the conversion of the _ids to the int type.

#### 🛠 What I changed:

- Change type to int of _id in the base controller and the base manager
